### PR TITLE
fix: BestMatches grid overflow + dedup same-location pins

### DIFF
--- a/components/forecast/BestMatchStrip.module.css
+++ b/components/forecast/BestMatchStrip.module.css
@@ -134,15 +134,20 @@
   padding:         0 4px;
 }
 
-.cards[data-count='1'] { grid-template-columns: 1fr; }
-.cards[data-count='2'] { grid-template-columns: repeat(2, 1fr); }
-.cards[data-count='3'] { grid-template-columns: repeat(3, 1fr); }
-.cards[data-count='4'] { grid-template-columns: repeat(4, 1fr); }
+/* minmax(0, 1fr) instead of 1fr — without the explicit 0 floor, grid
+   items default to min-width: auto, which is min-content width. A long
+   pin name or a wordy reason ("Drizzle in the forecast — conditions damp
+   but manageable.") refuses to shrink and pushes the whole grid past the
+   .strip container's right edge. */
+.cards[data-count='1'] { grid-template-columns: minmax(0, 1fr); }
+.cards[data-count='2'] { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+.cards[data-count='3'] { grid-template-columns: repeat(3, minmax(0, 1fr)); }
+.cards[data-count='4'] { grid-template-columns: repeat(4, minmax(0, 1fr)); }
 
 @media (max-width: 920px) {
   .cards[data-count='3'],
   .cards[data-count='4'] {
-    grid-template-columns: repeat(2, 1fr);
+    grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 }
 
@@ -150,7 +155,7 @@
   .cards[data-count='2'],
   .cards[data-count='3'],
   .cards[data-count='4'] {
-    grid-template-columns: 1fr;
+    grid-template-columns: minmax(0, 1fr);
   }
 }
 

--- a/components/forecast/BestMatchStrip.tsx
+++ b/components/forecast/BestMatchStrip.tsx
@@ -71,7 +71,11 @@ export default function BestMatchStrip({
   }
 
   // Score each pin = avg over selected days, sort desc, take top 4.
-  const candidates: Candidate[] = pins
+  // Dedup by location (lat/lon rounded to 3 decimals ≈ 110 m grid) since the
+  // pin store can hold the same place twice if the user saved it from two
+  // different flows. Keep the highest-scoring entry per location so the
+  // strip never renders two identical "Malibu Beach" cards.
+  const scored = pins
     .map((pin) => {
       const series = forecasts[pin.id];
       if (!series || series.length === 0) return null;
@@ -84,7 +88,16 @@ export default function BestMatchStrip({
       const goCount = selected.filter((d) => d.verdict === 'GO').length;
       return { pin, avg, goCount, best, daysCount: selected.length };
     })
-    .filter((c): c is Candidate => c !== null)
+    .filter((c): c is Candidate => c !== null);
+
+  const byLocation = new Map<string, Candidate>();
+  for (const c of scored) {
+    const key = `${c.pin.activity}@${c.pin.lat.toFixed(3)},${c.pin.lon.toFixed(3)}`;
+    const prev = byLocation.get(key);
+    if (!prev || c.avg > prev.avg) byLocation.set(key, c);
+  }
+
+  const candidates: Candidate[] = Array.from(byLocation.values())
     .sort((a, b) => b.avg - a.avg)
     .slice(0, 4);
 


### PR DESCRIPTION
Two visual bugs on /forecast.

## Grid overflow
BestMatches cards spilled past the .strip container's right edge on narrow viewports (notably 3:2 monitors at ~1180px — wide enough to skip the 920px → 2-column breakpoint, narrow enough that intrinsic card width exceeds column width). Grid items default to min-width: auto = min-content, so long pin names or wordy reasons refused to shrink.

Fix: `repeat(N, 1fr)` → `repeat(N, minmax(0, 1fr))`. Cards now truncate via the existing text-overflow: ellipsis instead of overflowing.

## Duplicate same-location pins
Pin store can hold the same lat/lon twice if saved from two flows. Strip was rendering identical "Malibu Beach" cards next to each other (both 95 GO).

Fix: dedup candidates by `activity@lat,lon` (3-decimal grid ≈ 110m) before slicing top 4. Keep the higher-avg entry per location.

## Test plan
- [ ] /forecast with days selected — 4 cards fit inside the .strip at any window width down to 520px
- [ ] No duplicate Malibu Beach (or any other) card